### PR TITLE
Add option to restart stackdriver hourly

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -44,3 +44,11 @@
     state: started
     name: google-fluentd
     enabled: yes
+
+- name: Restart cron job exists
+  cron:
+    name: "restart stackdriver"
+    minute: 0
+    job: "service google-fluentd restart"
+    user: "root"
+  when: stackdriver_restart

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -8,7 +8,7 @@ packages:
   - google-fluentd
   - google-fluentd-catch-all-config
 stackdriver_collectd_service: stackdriver-agent
-
+stackdriver_restart: false
 
 #stackdriver_package_repo:
 #  http://repo.stackdriver.com/stackdriver-el{{ ansible_distribution_major_version }}.repo


### PR DESCRIPTION
Stackdriver logs seem to occasionally get stuck and stop tailing. After timeboxing some time to look at it and not being able to root-cause, adding an option(off by default) to restart the service every hour.